### PR TITLE
added support for https remote

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -15,6 +15,10 @@ sendersBlacklist:
 serviceWhitelist:
   - '_homekit._tcp.local'
   - '_hap._tcp.local'
+# UNCOMMENT THIS TO ADD SUPPORT FOR CHROMECAST
+#  - '_googlecast._tcp.local'
 
 # UNCOMMENT THIS TO START AS A CLIENT:
 # remote: 192.168.1.10
+# or
+# remote: https://192.168.1.10

--- a/lib/link.ts
+++ b/lib/link.ts
@@ -68,7 +68,7 @@ export class Client<T> extends Link<T> {
     super(false);
     this.isSocketConnected = false;
 
-    const remoteAddress = `http://${config.get('remote')}:${config.get('port')}`;
+    const remoteAddress = `${String(config.get('remote')).match(/^https?:\/\//) ? '' : 'http://'}${config.get('remote')}:${config.get('port')}`;
     console.log(`Connecting to ${remoteAddress}...`);
 
     const PrimusSocket = Primus.createSocket({


### PR DESCRIPTION
I wanted to add support for HTTPS here because I don't have any other ports open on my internal subnet as I have a reverse proxy setup to accept connections for 80/443 only (80 automatically redirects to 443). 

I also added a comment about the Chromecast service because I didn't know what the service name was and it took me a bit to find it. Hopefully it saves someone some time later.